### PR TITLE
Add bento check to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,9 @@ workflows:
       - type_checks:
           requires:
             - deps
-#      - analysis:
-#          requires:
-#            - deps
+      - analysis:
+          requires:
+            - deps
 
 jobs:
   # git clone
@@ -116,4 +116,4 @@ jobs:
           key: v2-dep-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - run:
           command: |
-            pipenv run bento --agree --email mischa@jetbridge.com check
+            pipenv run bento --agree --email mischa@jetbridge.com check --no-pager


### PR DESCRIPTION
As pointed out in https://circleci.com/gh/jetbridge/jetkit-flask/168, the `bento check` step is failing due to `less`. This fixes that and enables back the job