### PR TITLE
Add ON CONFLICT DO NOTHING option for upsert

### DIFF
--- a/jetkit/db/upsert.py
+++ b/jetkit/db/upsert.py
@@ -57,10 +57,8 @@ class Upsertable:
 
         # execute insert
         res = session.execute(insert_query)
-        if (
-            not should_return_result
-            or on_conflict is OnConflictBehavior.ON_CONFLICT_DO_NOTHING
-        ):  # noqa: W503
+        is_do_nothing = on_conflict is OnConflictBehavior.ON_CONFLICT_DO_NOTHING
+        if not should_return_result or is_do_nothing:
             # if we don't care about getting the inserted object, we can stop now
             # if DO NOTHING then we don't get an inserted_pk
             return None

--- a/jetkit/db/upsert.py
+++ b/jetkit/db/upsert.py
@@ -1,6 +1,13 @@
 from typing import Any, Dict, List, Optional
 from flask_sqlalchemy import Model
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from enum import unique, Enum
+
+
+@unique
+class OnConflictBehavior(Enum):
+    ON_CONFLICT_DO_UPDATE = "DO_UPDATE"
+    ON_CONFLICT_DO_NOTHING = "DO_NOTHING"
 
 
 class Upsertable:
@@ -14,6 +21,7 @@ class Upsertable:
         set_: Dict[str, Any] = None,
         should_return_result=True,
         values: Dict[str, Any],
+        on_conflict: OnConflictBehavior = OnConflictBehavior.ON_CONFLICT_DO_UPDATE,
     ) -> Optional[Model]:  # noqa T484
         """Insert or update if index_elements match.
 
@@ -34,19 +42,27 @@ class Upsertable:
         else:
             raise Exception("constraint or index_elements must be specified")
 
-        # create INSERT ... ON CONFLICT DO UPDATE statement
-        insert_query = (
-            pg_insert(row_class)
-            .on_conflict_do_update(**conflict, set_=set_)
-            .values(**values)
-        )
+        # create INSERT ... ON CONFLICT DO _____ statement
+        insert_query = pg_insert(row_class)
 
+        if on_conflict is OnConflictBehavior.ON_CONFLICT_DO_UPDATE:
+            insert_query = insert_query.on_conflict_do_update(**conflict, set_=set_)
+        elif on_conflict is OnConflictBehavior.ON_CONFLICT_DO_NOTHING:
+            insert_query = insert_query.on_conflict_do_nothing(**conflict)
+        else:
+            raise RuntimeError(f"Invalid OnConflictBehavior: {on_conflict}")
+
+        insert_query = insert_query.values(**values)
         session = row_class.query.session
 
         # execute insert
         res = session.execute(insert_query)
-        if not should_return_result:
+        if (
+            not should_return_result
+            or on_conflict is OnConflictBehavior.ON_CONFLICT_DO_NOTHING
+        ):
             # if we don't care about getting the inserted object, we can stop now
+            # if DO NOTHING then we don't get an inserted_pk
             return None
 
         # retrieve inserted row

--- a/jetkit/db/upsert.py
+++ b/jetkit/db/upsert.py
@@ -60,7 +60,7 @@ class Upsertable:
         if (
             not should_return_result
             or on_conflict is OnConflictBehavior.ON_CONFLICT_DO_NOTHING
-        ):
+        ):  # noqa: W503
             # if we don't care about getting the inserted object, we can stop now
             # if DO NOTHING then we don't get an inserted_pk
             return None

--- a/jetkit/test/test_upsert.py
+++ b/jetkit/test/test_upsert.py
@@ -1,0 +1,31 @@
+from jetkit.test.app import db
+from jetkit.db.upsert import Upsertable, OnConflictBehavior
+
+
+class UserWithEmail(db.Model, Upsertable):
+    email = db.Column(db.Text(), unique=True)
+    counter = db.Column(db.Integer())
+
+
+def test_upsert_on_conflict_do_something_or_nothing(session):
+    email = "mischa@jetbridge.com"
+    u1 = UserWithEmail.upsert_row(
+        UserWithEmail, index_elements=["email"], values=dict(email=email, counter=1)
+    )
+
+    assert u1.counter == 1
+
+    # on conflict do update
+    UserWithEmail.upsert_row(
+        UserWithEmail, index_elements=["email"], values=dict(email=email, counter=2)
+    )
+    assert u1.counter == 2
+
+    # on conflict do nothing
+    UserWithEmail.upsert_row(
+        UserWithEmail,
+        index_elements=["email"],
+        values=dict(email=email, counter=3),
+        on_conflict=OnConflictBehavior.ON_CONFLICT_DO_NOTHING,
+    )
+    assert u1.counter == 2

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md") as f:
 
 NAME = "JetKit-Flask"
 DESCRIPTION = "Rapid web application development."
-VERSION = "8.0.0"
+VERSION = "8.1.0"
 REQUIRES_PYTHON = ">=3.6.0"
 
 setup(
@@ -13,7 +13,7 @@ setup(
     version=VERSION,
     python_requires=REQUIRES_PYTHON,
     url="https://github.com/jetbridge/jetkit-flask",
-    license="ABRMS",
+    license="MIT",
     author="JetBridge",
     author_email="mischa@jetbridge.com",
     description=DESCRIPTION,


### PR DESCRIPTION
Read the docs here: https://www.postgresql.org/docs/current/sql-insert.html
under "ON CONFLICT Clause"

If we want to just make sure a row exists, like a simple many-to-many mapping table, this is a faster way of doing it instead of a redundant `UPDATE` 